### PR TITLE
Patch V2.4.2 - Fix domain latest link update

### DIFF
--- a/src/components/Sites/routes/DomainManagement/components/DomainItem/DomainItem.tsx
+++ b/src/components/Sites/routes/DomainManagement/components/DomainItem/DomainItem.tsx
@@ -85,7 +85,7 @@ const DomainItem: React.FC<IDeploymentItemProps> = ({
       name: editDomainName !== domain ? editDomainName : undefined,
       link:
         deployedSite === "latest"
-          ? (sortedDeployments || [{ sitePreview: "" }])[0].sitePreview || ""
+          ? (sortedDeployments || [{ sitePreview: undefined }])[0]?.sitePreview
           : deployedSite !== link
           ? deployedSite
           : undefined,

--- a/src/components/Sites/routes/DomainManagement/components/DomainItem/DomainItem.tsx
+++ b/src/components/Sites/routes/DomainManagement/components/DomainItem/DomainItem.tsx
@@ -84,7 +84,9 @@ const DomainItem: React.FC<IDeploymentItemProps> = ({
       orgId: selectedOrg?._id,
       name: editDomainName !== domain ? editDomainName : undefined,
       link:
-        deployedSite !== link && deployedSite !== "latest"
+        deployedSite === "latest"
+          ? (sortedDeployments || [{ sitePreview: "" }])[0].sitePreview || ""
+          : deployedSite !== link
           ? deployedSite
           : undefined,
       isLatest,


### PR DESCRIPTION
## What is the issue?
Updating a domain from a specific deployment link to the latest (automated) deployment does not link to the latest deployment link in the domain resolver.
With this patch, this issue is fixed.